### PR TITLE
Correct minor spelling errors preventing the proper icons from showing

### DIFF
--- a/disk_root/ventoy/ventoy.json
+++ b/disk_root/ventoy/ventoy.json
@@ -47,8 +47,8 @@
             "class": "elementaryos"
         },
         {
-            "key": "Federa-",
-            "class": "federa"
+            "key": "Fedora-",
+            "class": "fedora"
         },
         {
             "key": "Ghost",
@@ -63,7 +63,7 @@
             "class": "macosx"
         },
         {
-            "key": "openSUSU-",
+            "key": "openSUSE-",
             "class": "opensuse"
         },
         {


### PR DESCRIPTION
for Fedora and openSUSE